### PR TITLE
addition of MAPFRE endorsement certification

### DIFF
--- a/submissions/functional/endorsement/1.2.0/61074175_MAPFRE_OP_v1_endorsement_v1.2.0-HB_02-01-2025.json
+++ b/submissions/functional/endorsement/1.2.0/61074175_MAPFRE_OP_v1_endorsement_v1.2.0-HB_02-01-2025.json
@@ -1,0 +1,9 @@
+{
+	"api": "endorsement_v1.2.0",
+	"sd": "14703",
+	"docusign_id": "2d6b083e-5af0-44ce-924e-ebc500aea50f",
+	"test_plan_uri": [
+		"https://web.conformance.directory.opinbrasil.com.br/plan-detail.html?plan=8S87TcvNtcBxu\u0026public=true",
+		"https://web.conformance.directory.opinbrasil.com.br/plan-detail.html?plan=18ULsbC5J0YeZ\u0026public=true"
+	]
+}


### PR DESCRIPTION
Combination of two existing ones, as demanded via SD 14703:

-> https://github.com/br-openinsurance/Conformance/blob/main/submissions/functional/endorsement/1.2.0/61074175_MAPFRE_OP_v1_endorsement_v1.2.0_09-12-2024.json

-> https://github.com/br-openinsurance/Conformance/blob/main/submissions/functional/endorsement/1.2.0/61074175_MAPFRE_OP_v1_endorsement_v1.2.0-HB_10-09-2024.json